### PR TITLE
Permit only media timebase

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,22 +729,22 @@
             </tr>
             <tr>
               <td><code>#clockMode</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
               <td><code>#clockMode-gps</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
               <td><code>#clockMode-local</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
               <td><code>#clockMode-utc</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
@@ -826,7 +826,7 @@
               <td><code>#frameRate</code></td>
               <td>permitted</td>
               <td>
-                If the <a href="#dfn-document-instance" class="internalDFN" data-link-type="dfn">Document Instance</a> includes any clock time expression that uses the <code>frames</code> term or any
+                If the <a href="#dfn-document-instance" class="internalDFN" data-link-type="dfn">Document Instance</a> includes any time expression that uses the <code>frames</code> term or any
                 offset time expression that uses the <code>f</code> metric, the <code>ttp:frameRate</code> attribute <em class="rfc2119" title="SHALL">SHALL</em> be present
                 on the <code>tt</code> element.
               </td>
@@ -888,17 +888,17 @@
             </tr>
             <tr>
               <td><code>#markerMode</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
               <td><code>#markerMode-continuous</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
               <td><code>#markerMode-discontinuous</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
@@ -952,6 +952,11 @@
               <td>
                 See <a href="#profile-signaling" class="sec-ref">Profile Signaling</a>.
               </td>
+            </tr>
+            <tr>
+              <td><code>#region-timing</code></td>
+              <td>prohibited</td>
+              <td></td>
             </tr>
             <tr>
               <td><code>#resources</code></td>
@@ -1031,7 +1036,7 @@
             </tr>
             <tr>
               <td><code>#timeBase-clock</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>
@@ -1044,7 +1049,7 @@
             </tr>
             <tr>
               <td><code>#timeBase-smpte</code></td>
-              <td>permitted</td>
+              <td>prohibited</td>
               <td></td>
             </tr>
             <tr>


### PR DESCRIPTION
Change to permit only media timebase, to close #1. Specifically:

### Prohibit the following features:

* `#clockMode`
* `#clockMode-gps`
* `#clockMode-local`
* `#clockMode-utc`
* `#markerMode`
* `#markerMode-continuous`
* `#markerMode-discontinuous`
* `#region-timing`
* `#timeBase-clock`
* `#timeBase-smpte`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/adpt/pull/9.html" title="Last updated on Apr 4, 2019, 5:14 PM UTC (2e04802)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/adpt/9/13bad08...2e04802.html" title="Last updated on Apr 4, 2019, 5:14 PM UTC (2e04802)">Diff</a>