### PR TITLE
Change DFXP references to TTML2 profiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,8 +290,9 @@
         <li>MAY implement transformation semantic support for every Feature designated as optional by the profile, subject to any additional constraints on each Feature as specified by the profile.</li>
       </ul>
       <p class="note">
-        The use of the term presentation processor (transformation processor) within this document does not imply conformance to the DFXP Presentation Profile (or DFXP Transformation Profile) specified in [[TTML2]].
-        In other words, it is not considered an error for a presentation processor (transformation processor) to conform to the profile defined in this document without also conforming to the DFXP Presentation Profile (or DFXP Transformation Profile).
+        The use of the terms <a>presentation processor</a> 
+        and <a>transformation processor</a> within this document does not imply conformance <i>per se</i> to any of the Standard Profiles defined in [[TTML2]].
+        In other words, it is not considered an error for a <a>presentation processor</a> or <a>transformation processor</a> to conform to the profile defined in this document without also conforming to the TTML2  Presentation Profile or the TTML2 Transformation Profile.
       </p>
       <p class="note">
         This document does not specify presentation processor or transformation processor behavior when processing or transforming a non-conformant Document Instance.


### PR DESCRIPTION
Close #2 by removing mention of DFXP specifically and replacing with references to the TTML2 Presentation and Transformation profiles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/adpt/pull/11.html" title="Last updated on Apr 5, 2019, 4:34 PM UTC (64e3e56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/adpt/11/13bad08...64e3e56.html" title="Last updated on Apr 5, 2019, 4:34 PM UTC (64e3e56)">Diff</a>